### PR TITLE
Modified reference/tbp-api.yml - add spec for basic message parts

### DIFF
--- a/reference/tbp-api.yml
+++ b/reference/tbp-api.yml
@@ -325,6 +325,52 @@ components:
           properties:
             name:
               type: string
+              example: Welcome Message
+            parts:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - text
+                  text:
+                    type: string
+                    example: Welcome to the experience
+                  buttons:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - postback
+                            - open_url
+                        title:
+                          type: string
+                          example: Click me to start
+                        actions:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - send_message
+                              id:
+                                type: string
+                                format: uuid
+                            required:
+                              - type
+                              - id
+                      required:
+                        - type
+                        - title
+                required:
+                  - type
       required:
         - id
         - type

--- a/reference/tbp-api.yml
+++ b/reference/tbp-api.yml
@@ -351,8 +351,13 @@ components:
                         title:
                           type: string
                           example: Click me to start
+                        url:
+                          type: string
+                          format: uri
+                          description: required if type=open_url
                         actions:
                           type: array
+                          description: required if type=postback
                           items:
                             type: object
                             properties:


### PR DESCRIPTION
- supports message type=text
- supports buttons within message
- buttons can be postback to prompt a message to be sent when clicked, or open_url to prompt a URL to be opened in a browser when clicked